### PR TITLE
Change file name where subtitle is saved to avoid duplication of the extension

### DIFF
--- a/fese/container.py
+++ b/fese/container.py
@@ -116,7 +116,7 @@ class FFprobeVideoContainer:
             extension_to_use = convert_format or subtitle.convert_default_format
 
             sub_path = (
-                f"{os.path.splitext(self.path)[0]}.{subtitle.suffix}.{extension_to_use}"
+                f"{os.path.splitext(self.path)[0]}.{subtitle.language}.{extension_to_use}"
             )
             if custom_dir is not None:
                 basename_callback = basename_callback or os.path.basename
@@ -189,7 +189,7 @@ class FFprobeVideoContainer:
         collected_paths = set()
 
         for subtitle in subtitles:
-            sub_path = f"{os.path.splitext(self.path)[0]}.{subtitle.suffix}.{subtitle.extension}"
+            sub_path = f"{os.path.splitext(self.path)[0]}.{subtitle.language}.{subtitle.extension}"
             if custom_dir is not None:
                 basename_callback = basename_callback or os.path.basename
                 sub_path = os.path.join(custom_dir, basename_callback(sub_path))


### PR DESCRIPTION
With the current behavior, when a subtitle is extracted, because the suffix of a subtitle contains both the language and the format suffix (for example "en.ass"), the extracted filename becomes \<video file name\>.\<subtitle language\>.\<original subtitle format\>.\<extracted subtitle format\>. with this PR it would become \<video file name\>.\<subtitle language\>.\<extracted subtitle format\>